### PR TITLE
:sparkles: Add lpc40::dma_spi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ libhal_test_and_make_library(
   src/lpc40/power.cpp
   src/lpc40/pwm.cpp
   src/lpc40/spi.cpp
+  src/lpc40/dma_spi.cpp
   src/lpc40/stream_dac.cpp
   src/lpc40/uart.cpp
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -98,8 +98,11 @@ class libhal_arm_mcu_conan(ConanFile):
             self.cpp_info.exelinkflags = [
                 "-L" + os.path.join(self.package_folder, "linker_scripts")]
 
+            full_linker_path = os.path.join(
+                self.package_folder, "linker_scripts", platform + ".ld")
             # if the file exists, then we should use it as the linker
-            if os.path.isfile(platform + ".ld"):
+            if os.path.isfile(full_linker_path):
+                self.output.info(f"linker file '{full_linker_path}' found!")
                 self.cpp_info.exelinkflags.append("-T" + platform + ".ld")
 
             # if there is no match, then the linker script could be a pattern

--- a/demos/applications/spi.cpp
+++ b/demos/applications/spi.cpp
@@ -34,11 +34,14 @@ void application(resource_list& p_map)
 
   while (true) {
     using namespace std::literals;
-    std::array<hal::byte, 4> payload{ 0xDE, 0xAD, 0xBE, 0xEF };
+
+    std::array<hal::byte, 4> const payload{ 0xDE, 0xAD, 0xBE, 0xEF };
     std::array<hal::byte, 8> buffer{};
 
     hal::print(console, "Write operation\n");
+    chip_select.level(false);
     hal::write(spi, payload);
+    chip_select.level(true);
     hal::delay(clock, 1s);
 
     hal::print(console, "Read operation: [ ");
@@ -64,7 +67,7 @@ void application(resource_list& p_map)
       std::array<hal::byte, 4> id_data{};
 
       chip_select.level(false);
-      hal::delay(clock, 250ns);
+      hal::delay(clock, 250ns);  // wait at least 250ns
       hal::write_then_read(spi, read_manufacturer_id, id_data, 0xA5);
       chip_select.level(true);
 

--- a/demos/main.cpp
+++ b/demos/main.cpp
@@ -23,7 +23,7 @@ resource_list resources{};
 [[noreturn]] void terminate_handler() noexcept
 {
 
-  if (not resources.status_led && not resources.console) {
+  if (not resources.status_led && not resources.status_led) {
     // spin here until debugger is connected
     while (true) {
       continue;
@@ -72,4 +72,12 @@ int main()
   }  // Allow any other exceptions to terminate the application
 
   std::terminate();
+}
+
+extern "C"
+{
+  // This gets rid of an issue with libhal-exceptions in Debug mode.
+  void __assert_func()
+  {
+  }
 }

--- a/demos/platforms/lpc4078.cpp
+++ b/demos/platforms/lpc4078.cpp
@@ -15,8 +15,8 @@
 #include <libhal-arm-mcu/dwt_counter.hpp>
 #include <libhal-arm-mcu/lpc40/adc.hpp>
 #include <libhal-arm-mcu/lpc40/can.hpp>
-#include <libhal-arm-mcu/lpc40/clock.hpp>
 #include <libhal-arm-mcu/lpc40/constants.hpp>
+#include <libhal-arm-mcu/lpc40/dma_spi.hpp>
 #include <libhal-arm-mcu/lpc40/i2c.hpp>
 #include <libhal-arm-mcu/lpc40/input_pin.hpp>
 #include <libhal-arm-mcu/lpc40/interrupt_pin.hpp>
@@ -27,6 +27,7 @@
 #include <libhal-arm-mcu/lpc40/uart.hpp>
 #include <libhal-arm-mcu/startup.hpp>
 #include <libhal-arm-mcu/system_control.hpp>
+#include <libhal-lpc40/clock.hpp>
 
 #include <resource_list.hpp>
 
@@ -44,7 +45,7 @@ resource_list initialize_platform()
   static hal::lpc40::uart uart0(0,
                                 receive_buffer,
                                 hal::serial::settings{
-                                  .baud_rate = 38400,
+                                  .baud_rate = 115200,
                                 });
 
   static hal::lpc40::can can(2,
@@ -58,8 +59,8 @@ resource_list initialize_platform()
   static hal::lpc40::i2c i2c2(2);
   static hal::lpc40::interrupt_pin interrupt_pin(0, 29);
   static hal::lpc40::pwm pwm(1, 6);
-  static hal::lpc40::spi spi2(2);
-  static hal::lpc40::output_pin chip_select(1, 10);
+  static hal::lpc40::dma_spi spi2(2);
+  static hal::lpc40::output_pin chip_select(1, 8);
   static hal::lpc40::stream_dac_u8 stream_dac;
 
   return {

--- a/include/libhal-arm-mcu/lpc40/dma_spi.hpp
+++ b/include/libhal-arm-mcu/lpc40/dma_spi.hpp
@@ -1,0 +1,84 @@
+// Copyright 2024 Khalil Estell
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <span>
+
+#include <libhal/io_waiter.hpp>
+#include <libhal/spi.hpp>
+
+#include "constants.hpp"
+#include "pin.hpp"
+
+namespace hal::lpc40 {
+class dma_spi final : public hal::spi
+{
+public:
+  /// Information used to configure the spi bus
+  struct bus_info
+  {
+    /// peripheral id used to power on the spi peripheral at creation
+    peripheral peripheral_id;
+    /// spi data pin
+    pin clock;
+    /// spi clock pin
+    pin data_out;
+    /// spi clock pin
+    pin data_in;
+    /// clock function code
+    std::uint8_t clock_function;
+    /// scl pin function code
+    std::uint8_t data_out_function;
+    /// scl pin function code
+    std::uint8_t data_in_function;
+  };
+
+  /**
+   * @brief Construct a new spi object
+   *
+   * @param p_bus - bus number to use
+   * @param p_waiter - provides the implementation strategy for the time the CPU
+   * waits until the transfer has completed.
+   * @param p_settings - spi settings to achieve
+   * @throws hal::operation_not_supported - if the p_bus is not 0, 1, or 2 or if
+   * the spi settings could not be achieved.
+   */
+  dma_spi(std::uint8_t p_bus,
+          hal::io_waiter& p_waiter = hal::polling_io_waiter(),
+          spi::settings const& p_settings = {});
+  /**
+   * @brief Construct a new spi object using bus info directly
+   *
+   * @param p_bus - Full bus information
+   */
+  dma_spi(bus_info p_bus);
+
+  dma_spi(dma_spi const& p_other) = delete;
+  dma_spi& operator=(dma_spi const& p_other) = delete;
+  dma_spi(dma_spi&& p_other) noexcept = delete;
+  dma_spi& operator=(dma_spi&& p_other) noexcept = delete;
+  virtual ~dma_spi();
+
+private:
+  void driver_configure(settings const& p_settings) override;
+  void driver_transfer(std::span<hal::byte const> p_data_out,
+                       std::span<hal::byte> p_data_in,
+                       hal::byte p_filler) override;
+
+  hal::io_waiter* m_io_waiter;
+  bus_info m_bus;
+};
+}  // namespace hal::lpc40

--- a/src/lpc40/dma_spi.cpp
+++ b/src/lpc40/dma_spi.cpp
@@ -1,0 +1,311 @@
+// Copyright 2024 Khalil Estell
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstdint>
+
+#include <libhal-arm-mcu/lpc40/clock.hpp>
+#include <libhal-arm-mcu/lpc40/constants.hpp>
+#include <libhal-arm-mcu/lpc40/dma.hpp>
+#include <libhal-arm-mcu/lpc40/dma_spi.hpp>
+#include <libhal-arm-mcu/lpc40/interrupt.hpp>
+#include <libhal-arm-mcu/lpc40/power.hpp>
+#include <libhal-util/bit.hpp>
+#include <libhal-util/spi.hpp>
+#include <libhal-util/static_callable.hpp>
+
+#include "spi_reg.hpp"
+
+namespace hal::lpc40 {
+namespace {
+inline spi_reg_t* get_spi_reg(peripheral p_id)
+{
+  switch (p_id) {
+    case peripheral::ssp0:
+      return spi_reg0;
+    case peripheral::ssp1:
+      return spi_reg1;
+    case peripheral::ssp2:
+    default:
+      return spi_reg2;
+  }
+}
+
+inline bool still_sending(spi_reg_t* p_reg)
+{
+  return bit_extract<status_register::data_line_busy_bit>(p_reg->sr);
+}
+
+struct dma_peripheral_pair
+{
+  dma_peripheral rx;
+  dma_peripheral tx;
+};
+
+inline dma_peripheral_pair to_dma_peripheral_pair(dma_spi::bus_info& p_bus_info)
+{
+  switch (p_bus_info.peripheral_id) {
+    case peripheral::ssp0:
+      return {
+        .rx = dma_peripheral::spi0_rx_and_timer1_match1,
+        .tx = dma_peripheral::spi0_tx_and_timer1_match0,
+      };
+    case peripheral::ssp1:
+      return {
+        .rx = dma_peripheral::spi1_rx_and_timer2_match1,
+        .tx = dma_peripheral::spi1_tx_and_timer2_match0,
+      };
+    case peripheral::ssp2:
+      return {
+        .rx = dma_peripheral::spi2_rx_and_i2s_channel_1,
+        .tx = dma_peripheral::spi2_tx_and_i2s_channel_0,
+      };
+    default:
+      hal::safe_throw(hal::operation_not_supported(&p_bus_info));
+      break;
+  }
+}
+}  // namespace
+
+dma_spi::dma_spi(std::uint8_t p_bus_number,
+                 hal::io_waiter& p_waiter,
+                 dma_spi::settings const& p_settings)
+  : m_io_waiter(&p_waiter)
+  , m_bus{}
+{
+  // UM10562: Chapter 7: LPC408x/407x I/O configuration page 13
+  if (p_bus_number == 0) {
+    m_bus = {
+      .peripheral_id = peripheral::ssp0,
+      .clock = pin(0, 15),
+      .data_out = pin(0, 18),
+      .data_in = pin(0, 17),
+      .clock_function = 0b010,
+      .data_out_function = 0b010,
+      .data_in_function = 0b010,
+    };
+  } else if (p_bus_number == 1) {
+    m_bus = {
+      .peripheral_id = peripheral::ssp1,
+      .clock = pin(0, 7),
+      .data_out = pin(0, 9),
+      .data_in = pin(0, 8),
+      .clock_function = 0b010,
+      .data_out_function = 0b010,
+      .data_in_function = 0b010,
+    };
+  } else if (p_bus_number == 2) {
+    m_bus = {
+      .peripheral_id = peripheral::ssp2,
+      .clock = pin(1, 0),
+      .data_out = pin(1, 1),
+      .data_in = pin(1, 4),
+      .clock_function = 0b100,
+      .data_out_function = 0b100,
+      .data_in_function = 0b100,
+    };
+  } else {
+    // "Supported spi busses are 0, 1, and 2!";
+    hal::safe_throw(hal::operation_not_supported(this));
+  }
+
+  dma_spi::driver_configure(p_settings);
+}  // namespace hal::lpc40
+
+dma_spi::~dma_spi()
+{
+  power_off(m_bus.peripheral_id);
+}
+
+dma_spi::dma_spi(bus_info p_bus)
+  : m_bus(p_bus)
+{
+  if (p_bus.peripheral_id != peripheral::ssp0 &&
+      p_bus.peripheral_id != peripheral::ssp1 &&
+      p_bus.peripheral_id != peripheral::ssp2) {
+    hal::safe_throw(hal::operation_not_supported(this));
+  }
+}
+
+void dma_spi::driver_configure(settings const& p_settings)
+{
+  constexpr uint8_t spi_format_code = 0b00;
+
+  auto* reg = get_spi_reg(m_bus.peripheral_id);
+
+  // Power up peripheral
+  power_on(m_bus.peripheral_id);
+
+  // Set SSP frame format to SPI
+  bit_modify(reg->cr0).insert<control_register0::frame_bit>(spi_format_code);
+
+  // Set SPI to master mode by clearing
+  bit_modify(reg->cr1).clear<control_register1::slave_mode_bit>();
+
+  // Setup operating frequency
+  auto const input_clock = get_frequency(m_bus.peripheral_id);
+  auto const clock_divider = input_clock / p_settings.clock_rate;
+  auto const prescaler = static_cast<std::uint16_t>(clock_divider);
+  auto const prescaler_low = static_cast<std::uint8_t>(prescaler & 0xFF);
+  auto const prescaler_high = static_cast<std::uint8_t>(prescaler >> 8);
+  // Store lower half of prescalar in clock prescalar register
+  reg->cpsr = prescaler_low;
+  // Store upper 8 bit half of the prescalar in control register 0
+  bit_modify(reg->cr0).insert<control_register0::divider_bit>(prescaler_high);
+
+  // Set clock modes & bit size
+  //
+  // NOTE: In UM10562 page 611, you will see that DSS (Data Size Select) is
+  // equal to the bit transfer minus 1. So we can add 3 to our DataSize enum
+  // to get the appropriate transfer code.
+  constexpr std::uint8_t size_code_8bit = 0b111;
+
+  bit_modify(reg->cr0)
+    .insert<control_register0::polarity_bit>(p_settings.clock_idles_high)
+    .insert<control_register0::phase_bit>(
+      p_settings.data_valid_on_trailing_edge)
+    .insert<control_register0::data_bit>(size_code_8bit);
+
+  // Initialize SSP pins
+  m_bus.clock.function(m_bus.clock_function)
+    .analog(false)
+    .open_drain(false)
+    .resistor(pin_resistor::none);
+  m_bus.data_in.function(m_bus.data_in_function)
+    .analog(false)
+    .open_drain(false)
+    .resistor(pin_resistor::none);
+  m_bus.data_out.function(m_bus.data_out_function)
+    .analog(false)
+    .open_drain(false)
+    .resistor(pin_resistor::none);
+
+  // Enable DMA
+  bit_modify(reg->dmacr)
+    .set<dma_register::receive_dma_enable>()
+    .set<dma_register::transmit_dma_enable>();
+
+  // Enable SSP
+  bit_modify(reg->cr1).set<control_register1::spi_enable>();
+}
+
+void dma_spi::driver_transfer(std::span<hal::byte const> p_data_out,
+                              std::span<hal::byte> p_data_in,
+                              hal::byte p_filler)
+{
+  auto& reg = *get_spi_reg(m_bus.peripheral_id);
+
+  auto const dma_peripheral_pair = to_dma_peripheral_pair(m_bus);
+  auto const min = std::min(p_data_in.size(), p_data_out.size());
+
+  dma receive_configuration = {
+    .source = &reg.dr,
+    .destination = p_data_in.data(),
+    .length = min,
+    .source_increment = 0,
+    .destination_increment = 1,
+    .transfer_type = dma_transfer_type::peripheral_to_memory,
+    .source_transfer_width = dma_transfer_width::bit_8,
+    .destination_transfer_width = dma_transfer_width::bit_8,
+    .source_peripheral = dma_peripheral_pair.rx,
+    .destination_peripheral = dma_peripheral::memory_or_timer0_match0,
+    .source_burst_size = dma_burst_size::bytes_1,
+    .destination_burst_size = dma_burst_size::bytes_1,
+  };
+
+  dma transmit_configuration = {
+    .source = p_data_out.data(),
+    .destination = &reg.dr,
+    .length = min,
+    .source_increment = 1,
+    .destination_increment = 0,
+    .transfer_type = dma_transfer_type ::memory_to_peripheral,
+    .source_transfer_width = dma_transfer_width::bit_8,
+    .destination_transfer_width = dma_transfer_width::bit_8,
+    .source_peripheral = dma_peripheral::memory_or_timer0_match0,
+    .destination_peripheral = dma_peripheral_pair.tx,
+    .source_burst_size = dma_burst_size::bytes_1,
+    .destination_burst_size = dma_burst_size::bytes_1,
+  };
+
+  bool rx_done = false;
+  bool tx_done = false;
+
+  auto receive_completion_handler = [this, &rx_done]() {
+    rx_done = true;
+    m_io_waiter->resume();
+  };
+
+  auto transmit_completion_handler = [this, &tx_done]() {
+    tx_done = true;
+    m_io_waiter->resume();
+  };
+
+  if (receive_configuration.length == 0) {
+    rx_done = true;
+  } else {
+    hal::lpc40::setup_dma_transfer(receive_configuration,
+                                   receive_completion_handler);
+  }
+
+  if (transmit_configuration.length == 0) {
+    tx_done = true;
+  } else {
+    hal::lpc40::setup_dma_transfer(transmit_configuration,
+                                   transmit_completion_handler);
+  }
+
+  while (not(rx_done && tx_done)) {
+    m_io_waiter->wait();
+  }
+
+  rx_done = false;
+  tx_done = false;
+
+  if (p_data_in.size() == p_data_out.size()) {
+    return;
+  } else if (p_data_in.size() > p_data_out.size()) {
+    // In this case, we have more bytes we want to read back than bytes we want
+    // to transmit.
+    p_data_in = p_data_in.subspan(min);
+    receive_configuration.destination = p_data_in.data();
+    receive_configuration.length = p_data_in.size();
+    hal::lpc40::setup_dma_transfer(receive_configuration,
+                                   receive_completion_handler);
+
+    transmit_configuration.source = &p_filler;
+    transmit_configuration.length = p_data_in.size();
+    transmit_configuration.source_increment = 0;
+    hal::lpc40::setup_dma_transfer(transmit_configuration,
+                                   transmit_completion_handler);
+  } else {
+    // In this case, we have more bytes we want to transmit than we want to
+    // read. So skip the receive dma transfer...
+    rx_done = true;
+    p_data_out = p_data_out.subspan(min);
+    transmit_configuration.source = p_data_out.data();
+    transmit_configuration.length = p_data_out.size();
+    hal::lpc40::setup_dma_transfer(transmit_configuration,
+                                   transmit_completion_handler);
+  }
+
+  while (not(rx_done && tx_done)) {
+    m_io_waiter->wait();
+  }
+
+  // Stay in the loop until the bus is no longer active
+  while (still_sending(&reg)) {
+    m_io_waiter->wait();
+  }
+}
+}  // namespace hal::lpc40

--- a/src/lpc40/spi_reg.hpp
+++ b/src/lpc40/spi_reg.hpp
@@ -22,24 +22,25 @@ namespace hal::lpc40 {
 struct spi_reg_t
 {
   /*!< Offset: 0x000 Control Register 0 (R/W) */
-  volatile uint32_t cr0;
+  uint32_t volatile cr0;
   /*!< Offset: 0x004 Control Register 1 (R/W) */
-  volatile uint32_t cr1;
+  uint32_t volatile cr1;
   /*!< Offset: 0x008 Data Register (R/W) */
-  volatile uint32_t dr;
+  uint32_t volatile dr;
   /*!< Offset: 0x00C Status Register (R/ ) */
-  const volatile uint32_t sr;
+  uint32_t const volatile sr;
   /*!< Offset: 0x010 Clock Prescale Register (R/W) */
-  volatile uint32_t cpsr;
+  uint32_t volatile cpsr;
   /*!< Offset: 0x014 Interrupt Mask Set and Clear Register (R/W) */
-  volatile uint32_t imsc;
+  uint32_t volatile imsc;
   /*!< Offset: 0x018 Raw Interrupt Status Register (R/W) */
-  volatile uint32_t ris;
+  uint32_t volatile ris;
   /*!< Offset: 0x01C Masked Interrupt Status Register (R/W) */
-  volatile uint32_t mis;
+  uint32_t volatile mis;
   /*!< Offset: 0x020 SSPICR Interrupt Clear Register (R/W) */
-  volatile uint32_t icr;
-  volatile uint32_t dmacr;
+  uint32_t volatile icr;
+  /*!< Offset: 0x024 SSPnDMACR DMA control register (R/W) */
+  uint32_t volatile dmacr;
 };
 
 /// SSPn Control Register 0
@@ -87,9 +88,18 @@ struct control_register1  // NOLINT
 /// SSPn Status Register
 struct status_register  // NOLINT
 {
+  static constexpr auto transmit_fifo_not_full = bit_mask::from<1>();
+  static constexpr auto receive_fifo_not_empty = bit_mask::from<2>();
   /// This bit is 0 if the SSPn controller is idle, or 1 if it is currently
   /// sending/receiving a frame and/or the Tx FIFO is not empty.
   static constexpr auto data_line_busy_bit = bit_mask::from<4>();
+};
+
+/// SSPn dma Register
+struct dma_register  // NOLINT
+{
+  static constexpr auto receive_dma_enable = bit_mask::from<0>();
+  static constexpr auto transmit_dma_enable = bit_mask::from<1>();
 };
 
 inline spi_reg_t* spi_reg0 = reinterpret_cast<spi_reg_t*>(0x40088000);


### PR DESCRIPTION
- :bug: Reading back from dma_spi does not work!
- :bug: Fix linker file path for conanfile, fixing where the default linker is used, segfaulting the lpc40 because the top of stack was in 0x2000'0000 and not 0x1000'0000.
- :zap: In the `lpc40::spi`, reduce time gap between transmitted bytes by 46% (from 1160ns to 630ns @ 3MHz) by using the "fifo not full" status vs the busy() status. This allows the software to keep the spi peripheral fed with data.
- :test_tube: Manually tested using saleae to confirm signals. Rx is tested by pulling the line to 3v3 and checking that 0xFF is returned for all bytes in the sequence and by removing the connection and confirming that 0x00 is in all bytes of the receive buffer.