### PR TITLE
🔥 Removed lpc40 headers in demo/applications/dac.cpp

### DIFF
--- a/demos/applications/dac.cpp
+++ b/demos/applications/dac.cpp
@@ -13,10 +13,6 @@
 // limitations under the License.
 
 #include <libhal-arm-mcu/dwt_counter.hpp>
-#include <libhal-arm-mcu/lpc40/clock.hpp>
-#include <libhal-arm-mcu/lpc40/constants.hpp>
-#include <libhal-arm-mcu/lpc40/dac.hpp>
-#include <libhal-arm-mcu/lpc40/uart.hpp>
 #include <libhal-util/serial.hpp>
 #include <libhal-util/steady_clock.hpp>
 


### PR DESCRIPTION
lpc40 headers were not supposed to be present in any files
outside of their platform files.
