### PR TITLE
:bug: Fix interrupts hanging processor

### DIFF
--- a/src/interrupt.cpp
+++ b/src/interrupt.cpp
@@ -84,7 +84,7 @@ void setup_default_vector_table(std::span<interrupt_pointer> p_vector_table)
 constexpr bool is_the_same_vector_buffer(
   std::span<interrupt_pointer> p_vector_table)
 {
-  p_vector_table = p_vector_table.subspan(core_interrupts);
+  p_vector_table = p_vector_table.subspan(-core_interrupts);
   return (p_vector_table.data() == vector_table.data() &&
           p_vector_table.size() == vector_table.size());
 }

--- a/src/lpc40/dma.cpp
+++ b/src/lpc40/dma.cpp
@@ -1,7 +1,6 @@
 #include <cstdint>
 
 #include <array>
-#include <atomic>
 #include <bit>
 #include <mutex>
 

--- a/src/lpc40/i2c.cpp
+++ b/src/lpc40/i2c.cpp
@@ -14,13 +14,12 @@
 
 #include <cstdint>
 
-#include <libhal-lpc40/i2c.hpp>
-
-#include <libhal-armcortex/interrupt.hpp>
-#include <libhal-lpc40/clock.hpp>
-#include <libhal-lpc40/constants.hpp>
-#include <libhal-lpc40/interrupt.hpp>
-#include <libhal-lpc40/power.hpp>
+#include <libhal-arm-mcu/interrupt.hpp>
+#include <libhal-arm-mcu/lpc40/clock.hpp>
+#include <libhal-arm-mcu/lpc40/constants.hpp>
+#include <libhal-arm-mcu/lpc40/i2c.hpp>
+#include <libhal-arm-mcu/lpc40/interrupt.hpp>
+#include <libhal-arm-mcu/lpc40/power.hpp>
 #include <libhal-util/bit.hpp>
 #include <libhal-util/i2c.hpp>
 #include <libhal-util/static_callable.hpp>
@@ -224,7 +223,7 @@ i2c::i2c(std::uint8_t p_bus_number,
     }
   }
 
-  cortex_m::initialize_interrupts<value(irq::max)>();
+  lpc40::initialize_interrupts();
   i2c::driver_configure(p_settings);
 }
 

--- a/src/lpc40/spi.cpp
+++ b/src/lpc40/spi.cpp
@@ -18,7 +18,6 @@
 
 #include <libhal-lpc40/clock.hpp>
 #include <libhal-lpc40/constants.hpp>
-#include <libhal-lpc40/interrupt.hpp>
 #include <libhal-lpc40/power.hpp>
 #include <libhal-util/bit.hpp>
 #include <libhal-util/spi.hpp>

--- a/src/lpc40/stream_dac.cpp
+++ b/src/lpc40/stream_dac.cpp
@@ -1,4 +1,5 @@
 #include <concepts>
+
 #include <libhal-lpc40/clock.hpp>
 #include <libhal-lpc40/dma.hpp>
 #include <libhal-lpc40/pin.hpp>


### PR DESCRIPTION
The i2c demo does not work for lpc40 currently and this was due to a bug with the `hal::cortex_m::is_the_same_vector_buffer()` API. Because the offset was applied incorrectly, each invocation of this API always returned false, resulting in the interrupt vector table being reset each time its called. Meaning any peripheral that initializes the interrupt vector table, will wipe out all of the entires saved prior. The interrupts are still enabled, so when they are triggered, the interrupt invokes default_interrupt_handler which does nothing but spin, hanging the processor.

With some additional cleanup found.