### PR TITLE
:sparkles: Add pwm16_channel & pwm_group_manager to stm32f1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,22 +50,15 @@ libhal_test_and_make_library(
   src/stm32_generic/uart.cpp
 
   # stm32f1
-  src/stm32f1/can_reg.hpp
   src/stm32f1/can.cpp
   src/stm32f1/clock.cpp
-  src/stm32f1/dma.hpp
-  src/stm32f1/flash_reg.hpp
   src/stm32f1/input_pin.cpp
   src/stm32f1/interrupt.cpp
   src/stm32f1/output_pin.cpp
   src/stm32f1/pin.cpp
-  src/stm32f1/pin.hpp
   src/stm32f1/power.cpp
-  src/stm32f1/power.hpp
   src/stm32f1/pwm_wrapper.cpp
-  src/stm32f1/rcc_reg.hpp
   src/stm32f1/timer.cpp
-  src/stm32f1/uart_reg.hpp
   src/stm32f1/uart.cpp
   src/stm32f1/spi.cpp
   src/stm32f1/adc.cpp

--- a/include/libhal-arm-mcu/stm32_generic/pwm.hpp
+++ b/include/libhal-arm-mcu/stm32_generic/pwm.hpp
@@ -4,22 +4,25 @@
 #include <libhal/initializers.hpp>
 #include <libhal/pwm.hpp>
 #include <libhal/units.hpp>
-
-namespace hal::stm32f1 {
-class pwm_wrapper;
-}  // namespace hal::stm32f1
+#include <limits>
 
 namespace hal::stm32_generic {
 
-struct pwm_settings
+struct pwm_channel_info
 {
   /// Each Timer Peripheral has 2-4 channels, and this number allows the driver
   /// to use the correct output pin
-  int channel;
-  /// PWM depends on the frequency of the timer peripheral it uses.
-  hertz frequency;
+  u8 channel;
   /// Advanced timers work slightly different than general purpose ones.
   bool is_advanced;
+};
+
+struct pwm_timer_frequency
+{
+  /// The target frequency all PWM channels within a timer will be set to
+  u32 pwm_frequency;
+  /// The timer's input clock frequency
+  u32 timer_clock_frequency;
 };
 
 /**
@@ -28,10 +31,49 @@ struct pwm_settings
  * The user should instantiate a General Purpose or Advanced timer class first,
  * and then acquire a pwm pin through that class.
  */
-class pwm final : public hal::pwm
+class pwm_group_frequency final
 {
 public:
-  friend class hal::stm32f1::pwm_wrapper;
+  /**
+   * @brief Construct generic stm32 pwm driver
+   *
+   * Care should be taken in constructing this outside of a platform specific
+   * timer class. If both a platform specific timer class and this object exist,
+   * care must be taken to ensure that the drivers do not conflict with each
+   * others.
+   *
+   * @param p_reg is a void pointer that points to the beginning of a timer
+   * peripheral
+   */
+  pwm_group_frequency(hal::unsafe, void* p_reg);
+
+  pwm_group_frequency(pwm_group_frequency const& p_other) = delete;
+  pwm_group_frequency& operator=(pwm_group_frequency const& p_other) = delete;
+  pwm_group_frequency(pwm_group_frequency&& p_other) = default;
+  pwm_group_frequency& operator=(pwm_group_frequency&& p_other) = default;
+  ~pwm_group_frequency() = default;
+
+  /**
+   * @brief Set the frequency for all PWM channels controlled by the timer
+   * specified by the `p_reg` parameter passed at construction.
+   *
+   * @param p_timer_frequency - desired pwm frequency and input clock frequency
+   */
+  void set_group_frequency(pwm_timer_frequency p_timer_frequency);
+
+private:
+  void* m_reg = nullptr;
+};
+
+/**
+ * @brief This class should not be constructed directly.
+ *
+ * The user should instantiate a General Purpose or Advanced timer class first,
+ * and then acquire a pwm pin through that class.
+ */
+class pwm final
+{
+public:
   /**
    * @brief Construct generic stm32 pwm driver
    *
@@ -45,27 +87,74 @@ public:
    * @param p_settings consist of channel number, frequency of the timer, and a
    * boolean to indicate whether the timer is advanced or not.
    */
-  pwm(hal::unsafe, void* p_reg, pwm_settings p_settings);
-  pwm(pwm const& p_other) = delete;
-  pwm& operator=(pwm const& p_other) = delete;
+  pwm(hal::unsafe, void* p_reg, pwm_channel_info p_settings);
 
-  ~pwm() = default;
-
-private:
   /**
-   * @brief This constructor is constructed in pwm_wrapper.
+   * @brief Construct pwm uninitialized
+   *
    * The purpose of this is to send the settings through the initialize function
    * instead, because the channel calculation and pin configuration is done in
-   * the contructor and the regular constructor cannot be initialized through
+   * the constructor and the regular constructor cannot be initialized through
    * the initializer list.
+   *
+   * If this constructor is used, it is unsafe to call any API of this class
+   * before calling the `initialize()` API with the correct inputs. Once that
+   * API has been called without failure, then the other APIs will become
+   * available.
    */
-  pwm() = default;
-  void driver_frequency(hertz p_frequency) override;
-  void driver_duty_cycle(float p_duty_cycle) override;
-  void initialize(void* p_reg, pwm_settings p_settings);
+  pwm(hal::unsafe)
+  {
+  }
 
-  void* m_reg;
-  u32 volatile* m_compare_register_addr;
-  hertz m_clock_freq;
+  pwm(pwm const& p_other) = delete;
+  pwm& operator=(pwm const& p_other) = delete;
+  pwm(pwm&& p_other) = default;
+  pwm& operator=(pwm&& p_other) = default;
+  ~pwm() = default;
+
+  /**
+   * @brief Initialize the driver if the `pwm(hal::unsafe)` was used
+   *
+   * This API must be called if the `pwm(hal::unsafe)` was used in order to
+   * initialize this class.
+   *
+   * @param p_reg - address of the timer's peripheral
+   * @param p_settings - pwm settings for the timer peripheral
+   */
+  void initialize(hal::unsafe, void* p_reg, pwm_channel_info p_settings);
+
+  /**
+   * @brief Acquire the operating frequency of the PWM channel
+   *
+   * @param p_timer_clock_frequency - the clock frequency driving the timer
+   * peripheral.
+   * @return u32 - the frequency of the PWM signal
+   */
+  u32 frequency(u32 p_timer_clock_frequency);
+
+  /**
+   * @brief Set pwm channel duty cycle using u16 value from 0x0000 to 0xFFFF
+   *
+   * @param p_duty_cycle - pwm duty cycle proportional value from 0x0000 to
+   * 0xFFFF.
+   */
+  void duty_cycle(u16 p_duty_cycle);
+
+  /**
+   * @brief Set the duty cycle using a float
+   *
+   * @param p_duty_cycle - value from
+   */
+  inline void duty_cycle(float p_duty_cycle)
+  {
+    constexpr auto u16_max = std::numeric_limits<u16>::max();
+    auto const clamped_duty_cycle = std::clamp(p_duty_cycle, 0.0f, 1.0f);
+    auto const u16_value = static_cast<u16>(clamped_duty_cycle * u16_max);
+    duty_cycle(u16_value);
+  }
+
+private:
+  void* m_reg = nullptr;
+  u32 volatile* m_compare_register_addr = nullptr;
 };
 }  // namespace hal::stm32_generic

--- a/include/libhal-arm-mcu/stm32f1/pwm_wrapper.hpp
+++ b/include/libhal-arm-mcu/stm32f1/pwm_wrapper.hpp
@@ -2,17 +2,18 @@
 
 #include <libhal-arm-mcu/stm32_generic/pwm.hpp>
 #include <libhal-arm-mcu/stm32f1/constants.hpp>
-#include <libhal-arm-mcu/stm32f1/timer.hpp>
+#include <libhal/pwm.hpp>
 #include <libhal/units.hpp>
 
 namespace hal::stm32f1 {
+enum class pins : u8;
+
 template<hal::stm32f1::peripheral select>
 class advanced_timer;
 
 template<hal::stm32f1::peripheral select>
 class general_purpose_timer;
 
-enum class pins : u8;
 /**
  * @brief This class is a wrapper for the pwm class.
  *
@@ -21,7 +22,7 @@ enum class pins : u8;
  * object is returned to the timer instance and can be used as an hal::pwm in
  * any application.
  */
-class pwm_wrapper : public hal::pwm
+class pwm16_channel : public hal::pwm16_channel
 {
 public:
   template<hal::stm32f1::peripheral select>
@@ -30,12 +31,11 @@ public:
   template<hal::stm32f1::peripheral select>
   friend class hal::stm32f1::general_purpose_timer;
 
-  pwm_wrapper(pwm_wrapper const& p_other) = delete;
-  pwm_wrapper& operator=(pwm_wrapper const& p_other) = delete;
-  pwm_wrapper(pwm_wrapper&& p_other) noexcept = delete;
-  pwm_wrapper& operator=(pwm_wrapper&& p_other) noexcept = delete;
-
-  ~pwm_wrapper();
+  pwm16_channel(pwm16_channel const& p_other) = delete;
+  pwm16_channel& operator=(pwm16_channel const& p_other) = delete;
+  pwm16_channel(pwm16_channel&& p_other) noexcept = default;
+  pwm16_channel& operator=(pwm16_channel&& p_other) noexcept = default;
+  ~pwm16_channel();
 
 private:
   /**
@@ -56,15 +56,125 @@ private:
    *
    * @throws device_or_resource_busy when a pwm is already being used on a pin.
    */
-  pwm_wrapper(void* p_reg,
-              stm32f1::peripheral p_select,
-              bool p_is_advanced,
-              stm32f1::pins p_pin);
+  pwm16_channel(void* p_reg,
+                stm32f1::peripheral p_select,
+                bool p_is_advanced,
+                stm32f1::pins p_pin);
+
+  u32 driver_frequency() override;
+  void driver_duty_cycle(u16 p_duty_cycle) override;
+
+  hal::stm32_generic::pwm m_pwm;
+  hal::u16 m_pin_num;
+  stm32f1::peripheral m_select;
+};
+
+/**
+ * @brief This class is a wrapper for the pwm class.
+ *
+ * It manages the pwm availability of the various different pins, and keeps
+ * track of whether a pwm is available or not. It inherits hal::pwm because this
+ * object is returned to the timer instance and can be used as an hal::pwm in
+ * any application.
+ */
+class pwm_group_frequency : public hal::pwm_group_manager
+{
+public:
+  template<hal::stm32f1::peripheral select>
+  friend class hal::stm32f1::advanced_timer;
+
+  template<hal::stm32f1::peripheral select>
+  friend class hal::stm32f1::general_purpose_timer;
+
+  pwm_group_frequency(pwm_group_frequency const& p_other) = delete;
+  pwm_group_frequency& operator=(pwm_group_frequency const& p_other) = delete;
+  pwm_group_frequency(pwm_group_frequency&& p_other) noexcept = default;
+  pwm_group_frequency& operator=(pwm_group_frequency&& p_other) noexcept =
+    default;
+  ~pwm_group_frequency() = default;
+
+private:
+  /**
+   * @brief The pwm constructor is private because the only way one should be
+   * able to access pwm is through the timer class
+   *
+   * @param p_reg is a void pointer that points to the beginning of a timer
+   * peripheral
+   * @param p_select is the timer peripheral that this instance is using.
+   * @param p_is_advanced whether the current peripheral is advanced or not
+   * @param p_pins This number is used to update the an internal bitmap
+   * containing which PWM pins have already been acquired as well as configure
+   * the pins and their channels. On construction the bit indicated by this
+   * value is checked to see if it is set. If it is set, an exception is thrown
+   * indicating that this resource has already been acquired. Otherwise, this
+   * driver sets that bit. On destruction that bit is cleared to allow another
+   * driver to utilize that pin in the future.
+   *
+   * @throws device_or_resource_busy when a pwm is already being used on a pin.
+   */
+  pwm_group_frequency(void* p_reg, stm32f1::peripheral p_select);
+
+  void driver_frequency(u32 p_hertz) override;
+
+  hal::stm32_generic::pwm_group_frequency m_pwm_frequency;
+  stm32f1::peripheral m_select;
+};
+
+/**
+ * @brief This class is a wrapper for the pwm class.
+ * @deprecated Please use pwm16_channel and/or pwm_group_frequency. This class
+ * implements the `hal::pwm` interface which will be deprecated in libhal 5.
+ *
+ * It manages the pwm availability of the various different pins, and keeps
+ * track of whether a pwm is available or not. It inherits hal::pwm because this
+ * object is returned to the timer instance and can be used as an hal::pwm in
+ * any application.
+ */
+class pwm : public hal::pwm
+{
+public:
+  template<hal::stm32f1::peripheral select>
+  friend class hal::stm32f1::advanced_timer;
+
+  template<hal::stm32f1::peripheral select>
+  friend class hal::stm32f1::general_purpose_timer;
+
+  pwm(pwm const& p_other) = delete;
+  pwm& operator=(pwm const& p_other) = delete;
+  pwm(pwm&& p_other) noexcept = default;
+  pwm& operator=(pwm&& p_other) noexcept = default;
+  ~pwm();
+
+private:
+  /**
+   * @brief The pwm constructor is private because the only way one should be
+   * able to access pwm is through the timer class
+   *
+   * @param p_reg is a void pointer that points to the beginning of a timer
+   * peripheral
+   * @param p_select is the timer peripheral that this instance is using.
+   * @param p_is_advanced whether the current peripheral is advanced or not
+   * @param p_pins This number is used to update the an internal bitmap
+   * containing which PWM pins have already been acquired as well as configure
+   * the pins and their channels. On construction the bit indicated by this
+   * value is checked to see if it is set. If it is set, an exception is thrown
+   * indicating that this resource has already been acquired. Otherwise, this
+   * driver sets that bit. On destruction that bit is cleared to allow another
+   * driver to utilize that pin in the future.
+   *
+   * @throws device_or_resource_busy when a pwm is already being used on a pin.
+   */
+  pwm(void* p_reg,
+      stm32f1::peripheral p_select,
+      bool p_is_advanced,
+      stm32f1::pins p_pin);
 
   void driver_frequency(hertz p_frequency) override;
   void driver_duty_cycle(float p_duty_cycle) override;
 
   hal::stm32_generic::pwm m_pwm;
+  hal::stm32_generic::pwm_group_frequency m_pwm_frequency;
   hal::u16 m_pin_num;
+  stm32f1::peripheral m_select;
 };
 }  // namespace hal::stm32f1

--- a/include/libhal-arm-mcu/stm32f1/timer.hpp
+++ b/include/libhal-arm-mcu/stm32f1/timer.hpp
@@ -225,7 +225,7 @@ class advanced_timer
 public:
   static_assert(
     select == peripheral::timer1 or select == peripheral::timer8,
-    "Only timer 1 or 8 is allowed as advanced timers for this driver");
+    "Only timer 1 or 8 is allowed as advanced timers for this driver.");
   using pin_type = decltype(get_pwm_timer_type<select>())::type;
 
   advanced_timer(advanced_timer const& p_other) = delete;
@@ -233,7 +233,24 @@ public:
   advanced_timer(advanced_timer&& p_other) noexcept = delete;
   advanced_timer& operator=(advanced_timer&& p_other) noexcept = delete;
 
-  advanced_timer() = default;
+  advanced_timer();
+
+  /**
+   * @brief Acquire a PWM channel from this timer
+   * @deprecated Use the `acquire_pwm16_channel` and
+   * `acquire_pwm_group_frequency` functions instead. This function will be
+   * removed in libhal 5.
+   *
+   * Only one PWM channel is allowed to exist per timer.
+   * If a PWM channel object is destroyed, then another PWM channel can be
+   * acquired from this timer.
+   *
+   * @throws hal::device_or_resource_busy - If the application attempts to
+   * acquire a pwm channel while a pwm channel bound to this timer already
+   * exists.
+   */
+  [[nodiscard]] hal::stm32f1::pwm acquire_pwm(pin_type p_pin);
+
   /**
    * @brief Acquire a PWM channel from this timer
    *
@@ -245,7 +262,14 @@ public:
    * acquire a pwm channel while a pwm channel bound to this timer already
    * exists.
    */
-  [[nodiscard]] hal::stm32f1::pwm_wrapper acquire_pwm(pin_type p_pin);
+  [[nodiscard]] hal::stm32f1::pwm16_channel acquire_pwm16_channel(
+    pin_type p_pin);
+
+  /**
+   * @brief Acquire a PWM group frequency driver
+   *
+   */
+  [[nodiscard]] hal::stm32f1::pwm_group_frequency acquire_pwm_group_frequency();
 };
 /**
  * @brief This template class takes can do any timer operation for timers 2
@@ -253,7 +277,7 @@ public:
  *
  * The peripheral ID is the template argument, in order to ensure that the pins
  * used correspond to the correct timer instantiation as well as the correct
- * coresponding pins at compile time.
+ * corresponding pins at compile time.
  */
 template<peripheral select>
 class general_purpose_timer
@@ -265,9 +289,8 @@ public:
       select == peripheral::timer9 or select == peripheral::timer10 or
       select == peripheral::timer11 or select == peripheral::timer12 or
       select == peripheral::timer13 or select == peripheral::timer14,
-    "Only timers 2, 3, 4,6,9,10,11,12,13 and 14 are allowed as general purpose "
-    "timers "
-    "for this driver");
+    "Only timers 2, 3, 4, 6, 9, 10, 11, 12, 13, and 14 are allowed as general "
+    "purpose timers for this driver.");
   using pin_type = decltype(get_pwm_timer_type<select>())::type;
 
   general_purpose_timer(general_purpose_timer const& p_other) = delete;
@@ -276,7 +299,23 @@ public:
   general_purpose_timer(general_purpose_timer&& p_other) noexcept = delete;
   general_purpose_timer& operator=(general_purpose_timer&& p_other) noexcept =
     delete;
-  general_purpose_timer() = default;
+  general_purpose_timer();
+
+  /**
+   * @brief Acquire a PWM channel from this timer
+   * @deprecated Use the `acquire_pwm16_channel` and
+   * `acquire_pwm_group_frequency` functions instead. This function will be
+   * removed in libhal 5.
+   *
+   * Only one PWM channel is allowed to exist per timer.
+   * If a PWM channel object is destroyed, then another PWM channel can be
+   * acquired from this timer.
+   *
+   * @throws hal::device_or_resource_busy - If the application attempts to
+   * acquire a pwm channel while a pwm channel bound to this timer already
+   * exists.
+   */
+  [[nodiscard]] hal::stm32f1::pwm acquire_pwm(pin_type p_pin);
 
   /**
    * @brief Acquire a PWM channel from this timer
@@ -289,7 +328,14 @@ public:
    * acquire a pwm channel while a pwm channel bound to this timer already
    * exists.
    */
-  [[nodiscard]] hal::stm32f1::pwm_wrapper acquire_pwm(pin_type p_pin);
+  [[nodiscard]] hal::stm32f1::pwm16_channel acquire_pwm16_channel(
+    pin_type p_pin);
+
+  /**
+   * @brief Acquire a PWM group frequency driver
+   *
+   */
+  [[nodiscard]] hal::stm32f1::pwm_group_frequency acquire_pwm_group_frequency();
 };
 
 }  // namespace hal::stm32f1

--- a/src/stm32_generic/pwm.cpp
+++ b/src/stm32_generic/pwm.cpp
@@ -197,7 +197,13 @@ u32 pwm::frequency(u32 p_input_clock_frequency)
 {
   timer_reg_t* reg = get_timer_reg(m_reg);
 
-  auto const prescaled_clock = p_input_clock_frequency / reg->prescale_register;
+  // See page 419 in RM0008.pdf to find this equation:
+  //
+  //   Bits 15:0 PSC[15:0]: Prescaler value
+  //   The counter clock frequency CK_CNT is equal to fCK_PSC / (PSC[15:0] + 1)
+  //
+  auto const prescale_value = reg->prescale_register + 1;
+  auto const prescaled_clock = p_input_clock_frequency / prescale_value;
   auto const final_frequency = prescaled_clock / reg->auto_reload_register;
 
   return final_frequency;

--- a/src/stm32f1/pwm_wrapper.cpp
+++ b/src/stm32f1/pwm_wrapper.cpp
@@ -1,14 +1,14 @@
 #include <utility>
 
-#include "libhal-arm-mcu/stm32_generic/pwm.hpp"
-#include "libhal-arm-mcu/stm32f1/constants.hpp"
-#include "libhal-arm-mcu/stm32f1/pwm_wrapper.hpp"
+#include <libhal-arm-mcu/stm32_generic/pwm.hpp>
+#include <libhal-arm-mcu/stm32f1/constants.hpp>
+#include <libhal-arm-mcu/stm32f1/pwm_wrapper.hpp>
+#include <libhal-arm-mcu/stm32f1/timer.hpp>
 #include <libhal/error.hpp>
 #include <libhal/pwm.hpp>
 #include <libhal/units.hpp>
 
 #include "pin.hpp"
-#include "power.hpp"
 
 namespace {
 /**
@@ -18,18 +18,19 @@ hal::u32 m_availability;
 }  // namespace
 
 namespace hal::stm32f1 {
-
-pwm_wrapper::pwm_wrapper(void* p_reg,
-                         stm32f1::peripheral p_select,
-                         bool p_is_advanced,
-                         stm32f1::pins p_pin)
-  : m_pin_num(hal::value(p_pin))
+pwm::pwm(void* p_reg,
+         stm32f1::peripheral p_select,
+         bool p_is_advanced,
+         stm32f1::pins p_pin)
+  : m_pwm(unsafe{})
+  , m_pwm_frequency(unsafe{}, p_reg)
+  , m_pin_num(hal::value(p_pin))
+  , m_select(p_select)
 {
   // a generic pwm class requires a pin and a channel in order to use the right
-  // registers, therefore we pass in the channel as an argumet in the generic
+  // registers, therefore we pass in the channel as an argument in the generic
   // pwm class's constructor
-  int channel = 0;
-  power_on(p_select);
+  u8 channel = 0;
   switch (p_pin) {
     case pins::pa0:
       configure_pin({ .port = 'A', .pin = 0 }, push_pull_alternative_output);
@@ -122,29 +123,189 @@ pwm_wrapper::pwm_wrapper(void* p_reg,
     default:
       std::unreachable();
   }
-  m_pwm.initialize(p_reg,
-                   { .channel = channel,
-                     .frequency = stm32f1::frequency(p_select),
-                     .is_advanced = p_is_advanced });
+
+  m_pwm.initialize(unsafe{},
+                   p_reg,
+                   {
+                     .channel = channel,
+                     .is_advanced = p_is_advanced,
+                   });
+
   auto const pwm_pin_mask = bit_mask::from(m_pin_num);
   if (not hal::bit_extract(pwm_pin_mask, m_availability)) {
-    bit_modify(m_availability)
-      .set(pwm_pin_mask);  // need to handle pwm pin availability somewhere
+    bit_modify(m_availability).set(pwm_pin_mask);
   } else {
     hal::safe_throw(hal::device_or_resource_busy(nullptr));
   }
 }
-void pwm_wrapper::driver_frequency(hertz p_frequency)
+
+void pwm::driver_frequency(hertz p_frequency)
 {
-  m_pwm.driver_frequency(p_frequency);
+  m_pwm_frequency.set_group_frequency({
+    .pwm_frequency = static_cast<u32>(p_frequency),
+    .timer_clock_frequency = static_cast<u32>(stm32f1::frequency(m_select)),
+  });
 }
-void pwm_wrapper::driver_duty_cycle(float p_duty_cycle)
+
+void pwm::driver_duty_cycle(float p_duty_cycle)
 {
-  m_pwm.driver_duty_cycle(p_duty_cycle);
+  m_pwm.duty_cycle(p_duty_cycle);
 }
-pwm_wrapper::~pwm_wrapper()
+
+pwm::~pwm()
 {
   auto const pwm_pin_mask = bit_mask::from(m_pin_num);
   bit_modify(m_availability).clear(pwm_pin_mask);
+}
+
+pwm16_channel::pwm16_channel(void* p_reg,
+                             stm32f1::peripheral p_select,
+                             bool p_is_advanced,
+                             stm32f1::pins p_pin)
+  : m_pwm(unsafe{})
+  , m_pin_num(hal::value(p_pin))
+  , m_select(p_select)
+{
+  // a generic pwm class requires a pin and a channel in order to use the right
+  // registers, therefore we pass in the channel as an argument in the generic
+  // pwm class's constructor
+  u8 channel = 0;
+  switch (p_pin) {
+    case pins::pa0:
+      configure_pin({ .port = 'A', .pin = 0 }, push_pull_alternative_output);
+      channel = 1;
+      break;
+    case pins::pa1:
+      configure_pin({ .port = 'A', .pin = 1 }, push_pull_alternative_output);
+      channel = 2;
+      break;
+    case pins::pa2:
+      configure_pin({ .port = 'A', .pin = 2 }, push_pull_alternative_output);
+      channel = p_select == peripheral::timer9 ? 1 : 3;
+      break;
+    case pins::pa3:
+      configure_pin({ .port = 'A', .pin = 3 }, push_pull_alternative_output);
+      channel = p_select == peripheral::timer9 ? 2 : 4;
+      break;
+    case pins::pa6:
+      configure_pin({ .port = 'A', .pin = 6 }, push_pull_alternative_output);
+      channel = 1;
+      break;
+    case pins::pa7:
+      configure_pin({ .port = 'A', .pin = 7 }, push_pull_alternative_output);
+      channel = p_select == peripheral::timer14 ? 1 : 2;
+      break;
+    case pins::pb0:
+      configure_pin({ .port = 'B', .pin = 0 }, push_pull_alternative_output);
+      channel = 3;
+      break;
+    case pins::pb1:
+      configure_pin({ .port = 'B', .pin = 1 }, push_pull_alternative_output);
+      channel = 4;
+      break;
+    case pins::pb6:
+      configure_pin({ .port = 'B', .pin = 6 }, push_pull_alternative_output);
+      channel = 1;
+      break;
+    case pins::pb7:
+      configure_pin({ .port = 'B', .pin = 7 }, push_pull_alternative_output);
+      channel = 2;
+      break;
+    case pins::pb8:
+      configure_pin({ .port = 'B', .pin = 8 }, push_pull_alternative_output);
+      channel = p_select == peripheral::timer10 ? 1 : 3;
+      break;
+    case pins::pb9:
+      configure_pin({ .port = 'B', .pin = 9 }, push_pull_alternative_output);
+      channel = p_select == peripheral::timer11 ? 1 : 4;
+      break;
+    case pins::pa8:
+      configure_pin({ .port = 'A', .pin = 8 }, push_pull_alternative_output);
+      channel = 1;
+      break;
+    case pins::pa9:
+      configure_pin({ .port = 'A', .pin = 9 }, push_pull_alternative_output);
+      channel = 2;
+      break;
+    case pins::pa10:
+      configure_pin({ .port = 'A', .pin = 10 }, push_pull_alternative_output);
+      channel = 3;
+      break;
+    case pins::pa11:
+      configure_pin({ .port = 'A', .pin = 11 }, push_pull_alternative_output);
+      channel = 4;
+      break;
+    case pins::pc6:
+      configure_pin({ .port = 'C', .pin = 6 }, push_pull_alternative_output);
+      channel = 1;
+      break;
+    case pins::pc7:
+      configure_pin({ .port = 'C', .pin = 7 }, push_pull_alternative_output);
+      channel = 2;
+      break;
+    case pins::pc8:
+      configure_pin({ .port = 'C', .pin = 8 }, push_pull_alternative_output);
+      channel = 3;
+      break;
+    case pins::pc9:
+      configure_pin({ .port = 'C', .pin = 9 }, push_pull_alternative_output);
+      channel = 4;
+      break;
+    case pins::pb14:
+      configure_pin({ .port = 'B', .pin = 14 }, push_pull_alternative_output);
+      channel = 1;
+      break;
+    case pins::pb15:
+      configure_pin({ .port = 'B', .pin = 15 }, push_pull_alternative_output);
+      channel = 2;
+      break;
+    default:
+      std::unreachable();
+  }
+
+  m_pwm.initialize(unsafe{},
+                   p_reg,
+                   {
+                     .channel = channel,
+                     .is_advanced = p_is_advanced,
+                   });
+
+  auto const pwm_pin_mask = bit_mask::from(m_pin_num);
+  if (not hal::bit_extract(pwm_pin_mask, m_availability)) {
+    bit_modify(m_availability).set(pwm_pin_mask);
+  } else {
+    hal::safe_throw(hal::device_or_resource_busy(nullptr));
+  }
+}
+
+u32 pwm16_channel::driver_frequency()
+{
+  return m_pwm.frequency(static_cast<u32>(stm32f1::frequency(m_select)));
+}
+
+void pwm16_channel::driver_duty_cycle(u16 p_duty_cycle)
+{
+  m_pwm.duty_cycle(p_duty_cycle);
+}
+
+pwm16_channel::~pwm16_channel()
+{
+  auto const pwm_pin_mask = bit_mask::from(m_pin_num);
+  bit_modify(m_availability).clear(pwm_pin_mask);
+}
+
+pwm_group_frequency::pwm_group_frequency(void* p_reg,
+                                         stm32f1::peripheral p_select)
+  : m_pwm_frequency(unsafe{}, p_reg)
+  , m_select(p_select)
+{
+}
+
+void pwm_group_frequency::driver_frequency(u32 p_frequency)
+{
+  return m_pwm_frequency.set_group_frequency({
+    .pwm_frequency = p_frequency,
+    .timer_clock_frequency = static_cast<u32>(stm32f1::frequency(m_select)),
+  });
 }
 }  // namespace hal::stm32f1

--- a/src/stm32f1/pwm_wrapper.cpp
+++ b/src/stm32f1/pwm_wrapper.cpp
@@ -14,7 +14,7 @@ namespace {
 /**
  * @brief Static variable to track PWM availability.
  */
-hal::u32 m_availability;
+hal::u32 availability;
 }  // namespace
 
 namespace hal::stm32f1 {
@@ -132,8 +132,8 @@ pwm::pwm(void* p_reg,
                    });
 
   auto const pwm_pin_mask = bit_mask::from(m_pin_num);
-  if (not hal::bit_extract(pwm_pin_mask, m_availability)) {
-    bit_modify(m_availability).set(pwm_pin_mask);
+  if (not hal::bit_extract(pwm_pin_mask, availability)) {
+    bit_modify(availability).set(pwm_pin_mask);
   } else {
     hal::safe_throw(hal::device_or_resource_busy(nullptr));
   }
@@ -155,7 +155,7 @@ void pwm::driver_duty_cycle(float p_duty_cycle)
 pwm::~pwm()
 {
   auto const pwm_pin_mask = bit_mask::from(m_pin_num);
-  bit_modify(m_availability).clear(pwm_pin_mask);
+  bit_modify(availability).clear(pwm_pin_mask);
 }
 
 pwm16_channel::pwm16_channel(void* p_reg,
@@ -271,8 +271,8 @@ pwm16_channel::pwm16_channel(void* p_reg,
                    });
 
   auto const pwm_pin_mask = bit_mask::from(m_pin_num);
-  if (not hal::bit_extract(pwm_pin_mask, m_availability)) {
-    bit_modify(m_availability).set(pwm_pin_mask);
+  if (not hal::bit_extract(pwm_pin_mask, availability)) {
+    bit_modify(availability).set(pwm_pin_mask);
   } else {
     hal::safe_throw(hal::device_or_resource_busy(nullptr));
   }
@@ -291,7 +291,7 @@ void pwm16_channel::driver_duty_cycle(u16 p_duty_cycle)
 pwm16_channel::~pwm16_channel()
 {
   auto const pwm_pin_mask = bit_mask::from(m_pin_num);
-  bit_modify(m_availability).clear(pwm_pin_mask);
+  bit_modify(availability).clear(pwm_pin_mask);
 }
 
 pwm_group_frequency::pwm_group_frequency(void* p_reg,

--- a/src/stm32f1/timer.cpp
+++ b/src/stm32f1/timer.cpp
@@ -1,20 +1,25 @@
 #include <libhal-arm-mcu/stm32_generic/pwm.hpp>
 #include <libhal-arm-mcu/stm32f1/constants.hpp>
+#include <libhal-arm-mcu/stm32f1/pwm_wrapper.hpp>
 #include <libhal-arm-mcu/stm32f1/timer.hpp>
 #include <libhal-util/bit.hpp>
 #include <libhal-util/enum.hpp>
 #include <libhal/error.hpp>
 #include <libhal/units.hpp>
 
+#include "power.hpp"
+
 namespace hal::stm32f1 {
-inline void* pwm_timer1 =
-  reinterpret_cast<void*>(0x4001'2C00);  // advanced timer
+// Advanced timer
+inline void* pwm_timer1 = reinterpret_cast<void*>(0x4001'2C00);
+// General purpose timers 2 - 5
 inline void* pwm_timer2 = reinterpret_cast<void*>(0x4000'0000);
 inline void* pwm_timer3 = reinterpret_cast<void*>(0x4000'0400);
 inline void* pwm_timer4 = reinterpret_cast<void*>(0x4000'0800);
 inline void* pwm_timer5 = reinterpret_cast<void*>(0x4000'0C00);
-inline void* pwm_timer8 =
-  reinterpret_cast<void*>(0x4001'3400);  // advanced timer
+// Advanced timer
+inline void* pwm_timer8 = reinterpret_cast<void*>(0x4001'3400);
+// General purpose timers 9 - 14
 inline void* pwm_timer9 = reinterpret_cast<void*>(0x4001'4C00);
 inline void* pwm_timer10 = reinterpret_cast<void*>(0x4001'5000);
 inline void* pwm_timer11 = reinterpret_cast<void*>(0x4001'5400);
@@ -22,45 +27,111 @@ inline void* pwm_timer12 = reinterpret_cast<void*>(0x4000'1800);
 inline void* pwm_timer13 = reinterpret_cast<void*>(0x4000'1C00);
 inline void* pwm_timer14 = reinterpret_cast<void*>(0x4000'2000);
 
+namespace {
 template<peripheral select>
-hal::stm32f1::pwm_wrapper advanced_timer<select>::acquire_pwm(pin_type p_pin)
+void* peripheral_to_advanced_register()
 {
-  void* p_reg;
+  void* reg;
   if constexpr (select == peripheral::timer1) {
-    p_reg = pwm_timer1;
+    reg = pwm_timer1;
   } else {
-    p_reg = pwm_timer8;
+    reg = pwm_timer8;
   }
-  return { p_reg, select, true, static_cast<pins>(p_pin) };
+  return reg;
 }
 
 template<peripheral select>
-hal::stm32f1::pwm_wrapper general_purpose_timer<select>::acquire_pwm(
+void* peripheral_to_general_register()
+{
+  void* reg;
+  if constexpr (select == peripheral::timer2) {
+    reg = pwm_timer2;
+  } else if constexpr (select == peripheral::timer3) {
+    reg = pwm_timer3;
+  } else if constexpr (select == peripheral::timer4) {
+    reg = pwm_timer4;
+  } else if constexpr (select == peripheral::timer5) {
+    reg = pwm_timer5;
+  } else if constexpr (select == peripheral::timer9) {
+    reg = pwm_timer9;
+  } else if constexpr (select == peripheral::timer10) {
+    reg = pwm_timer10;
+  } else if constexpr (select == peripheral::timer11) {
+    reg = pwm_timer11;
+  } else if constexpr (select == peripheral::timer12) {
+    reg = pwm_timer12;
+  } else if constexpr (select == peripheral::timer13) {
+    reg = pwm_timer13;
+  } else {
+    reg = pwm_timer14;
+  }
+  return reg;
+}
+}  // namespace
+
+template<peripheral select>
+advanced_timer<select>::advanced_timer()
+{
+  power_on(select);
+}
+
+template<peripheral select>
+general_purpose_timer<select>::general_purpose_timer()
+{
+  power_on(select);
+}
+
+template<peripheral select>
+hal::stm32f1::pwm advanced_timer<select>::acquire_pwm(pin_type p_pin)
+{
+  return { peripheral_to_advanced_register<select>(),
+           select,
+           true,
+           static_cast<pins>(p_pin) };
+}
+
+template<peripheral select>
+hal::stm32f1::pwm general_purpose_timer<select>::acquire_pwm(pin_type p_pin)
+{
+
+  return { peripheral_to_general_register<select>(),
+           select,
+           false,
+           static_cast<pins>(p_pin) };
+}
+
+template<peripheral select>
+hal::stm32f1::pwm16_channel advanced_timer<select>::acquire_pwm16_channel(
   pin_type p_pin)
 {
-  void* p_reg;
-  if constexpr (select == peripheral::timer2) {
-    p_reg = pwm_timer2;
-  } else if constexpr (select == peripheral::timer3) {
-    p_reg = pwm_timer3;
-  } else if constexpr (select == peripheral::timer4) {
-    p_reg = pwm_timer4;
-  } else if constexpr (select == peripheral::timer5) {
-    p_reg = pwm_timer5;
-  } else if constexpr (select == peripheral::timer9) {
-    p_reg = pwm_timer9;
-  } else if constexpr (select == peripheral::timer10) {
-    p_reg = pwm_timer10;
-  } else if constexpr (select == peripheral::timer11) {
-    p_reg = pwm_timer11;
-  } else if constexpr (select == peripheral::timer12) {
-    p_reg = pwm_timer12;
-  } else if constexpr (select == peripheral::timer13) {
-    p_reg = pwm_timer13;
-  } else {
-    p_reg = pwm_timer14;
-  }
-  return { p_reg, select, false, static_cast<pins>(p_pin) };
+  return { peripheral_to_advanced_register<select>(),
+           select,
+           true,
+           static_cast<pins>(p_pin) };
+}
+
+template<peripheral select>
+hal::stm32f1::pwm16_channel
+general_purpose_timer<select>::acquire_pwm16_channel(pin_type p_pin)
+{
+  return { peripheral_to_general_register<select>(),
+           select,
+           false,
+           static_cast<pins>(p_pin) };
+}
+
+template<peripheral select>
+hal::stm32f1::pwm_group_frequency
+advanced_timer<select>::acquire_pwm_group_frequency()
+{
+  return { peripheral_to_advanced_register<select>(), select };
+}
+
+template<peripheral select>
+hal::stm32f1::pwm_group_frequency
+general_purpose_timer<select>::acquire_pwm_group_frequency()
+{
+  return { peripheral_to_general_register<select>(), select };
 }
 
 // Tell the compiler which instances to generate
@@ -76,5 +147,4 @@ template class general_purpose_timer<peripheral::timer11>;
 template class general_purpose_timer<peripheral::timer12>;
 template class general_purpose_timer<peripheral::timer13>;
 template class general_purpose_timer<peripheral::timer14>;
-
 }  // namespace hal::stm32f1


### PR DESCRIPTION
- Made stm32_generic/pwm classes moveable but not copyable. These objects are trivially relocatable
- Split generic pwm into pwm_group_frequency & pwm16_channel
- Compose hal::stm32f1::pwm (libhal v4) using the split pwm_group_frequency & pwm16_channel
- Add deprecation notice to `hal::stm32f1::pwm` in doxygen comments. We will not put this in as an attribute because old code may still need this and we don't want to give undue warnings yet.
- Remove interfaces from the split generic objects to allow their APIs to be more useful in portable code
- Remove frequency from pwm_settings and add an API called set_group_frequency which takes the latest clock frequency of the timer peripheral. That way if it changes, the code can react to it.
- Rename pwm_settings to pwm_channel_info since frequency is no longer a field and the only fields left are channel info fields.
- Rename hal::stm32f1::pwm_wrapper to just pwm as the "wrapper". Adding context that this a wrapper doesn't give any additional information. The pwm from stm32_generic and stm32f1 are separated by their namespaces which should be enough.
- Add `aquire_` APIs for `pwm16_channel` and `pwm_group_frequency`