### PR TITLE
:sparkles: `stm32f1::power_on()` now throws

### DIFF
--- a/include/libhal-arm-mcu/stm32f1/constants.hpp
+++ b/include/libhal-arm-mcu/stm32f1/constants.hpp
@@ -89,6 +89,7 @@ enum class peripheral : std::uint8_t
   system_timer = beyond_bus + 1,
   i2s = beyond_bus + 2,
 
+  max,
 };
 
 /// List of interrupt request numbers for this platform

--- a/src/stm32f1/power.cpp
+++ b/src/stm32f1/power.cpp
@@ -16,66 +16,57 @@
 #include <libhal-util/enum.hpp>
 
 #include <libhal-stm32f1/constants.hpp>
+#include <libhal/error.hpp>
 
 #include "power.hpp"
 #include "rcc_reg.hpp"
 
 namespace hal::stm32f1 {
 namespace {
-uint32_t volatile* get_enable_register(std::uint32_t p_bus_index)
+struct enable_register_info
 {
-  switch (p_bus_index) {
+  u32 volatile* reg;
+  hal::bit_mask mask;
+};
+
+enable_register_info get_enable_register_info(peripheral p_peripheral)
+{
+  auto const peripheral_value = hal::value(p_peripheral);
+  auto const bus_number = peripheral_value / bus_id_offset;
+  auto const mask = bit_mask::from(peripheral_value % bus_id_offset);
+  switch (bus_number) {
     case 0:
-      return &rcc->ahbenr;
+      return { .reg = &rcc->ahbenr, .mask = mask };
     case 1:
-      return &rcc->apb1enr;
+      return { .reg = &rcc->apb1enr, .mask = mask };
     case 2:
-      return &rcc->apb2enr;
+      return { .reg = &rcc->apb2enr, .mask = mask };
     default:
-      return nullptr;
+      hal::safe_throw(hal::argument_out_of_domain(nullptr));
   }
 }
 }  // namespace
 
 void power_on(peripheral p_peripheral)
 {
-  auto peripheral_value = hal::value(p_peripheral);
-  auto bus_number = peripheral_value / bus_id_offset;
+  auto const info = get_enable_register_info(p_peripheral);
 
-  auto bit_position =
-    static_cast<std::uint8_t>(peripheral_value % bus_id_offset);
-  auto enable_register = get_enable_register(bus_number);
-
-  if (enable_register) {
-    hal::bit_modify(*enable_register).set(bit_mask::from(bit_position));
+  if (hal::bit_extract(info.mask, *info.reg)) {
+    hal::safe_throw(hal::device_or_resource_busy(nullptr));
   }
+
+  hal::bit_modify(*info.reg).set(info.mask);
 }
 
 void power_off(peripheral p_peripheral)
 {
-  auto peripheral_value = hal::value(p_peripheral);
-  auto bus_number = peripheral_value / bus_id_offset;
-
-  auto bit_position =
-    static_cast<std::uint8_t>(peripheral_value % bus_id_offset);
-  auto enable_register = get_enable_register(bus_number);
-  if (enable_register) {
-    hal::bit_modify(*enable_register).clear(bit_mask::from(bit_position));
-  }
+  auto const info = get_enable_register_info(p_peripheral);
+  hal::bit_modify(*info.reg).clear(info.mask);
 }
 
 bool is_on(peripheral p_peripheral)
 {
-  auto peripheral_value = hal::value(p_peripheral);
-  auto bus_number = peripheral_value / bus_id_offset;
-
-  auto bit_position =
-    static_cast<std::uint8_t>(peripheral_value % bus_id_offset);
-  auto enable_register = get_enable_register(bus_number);
-
-  if (enable_register) {
-    return hal::bit_extract(bit_mask::from(bit_position), *enable_register);
-  }
-  return true;
+  auto const info = get_enable_register_info(p_peripheral);
+  return hal::bit_extract(info.mask, *info.reg);
 }
 }  // namespace hal::stm32f1

--- a/src/stm32f1/power.hpp
+++ b/src/stm32f1/power.hpp
@@ -22,12 +22,24 @@ namespace hal::stm32f1 {
 /**
  * @brief Power on the peripheral
  *
+ * This API also acts as a resource overlap detector. If this API is called
+ * twice on the same peripheral, it will throw an exception. Only drivers with
+ * control over the entire peripheral should call this API for their respective
+ * peripheral. This allows this API to detect when two driver attempt to utilize
+ * the same resource.
+ *
+ * @throws hal::device_or_resource_busy - if the peripheral is already powered
+ * on, constituting a violation of the 1 peripheral manager per peripheral rule.
+ * @throws hal::argument_out_of_domain - if the peripheral's value is outside of
+ * the bounds of the enum class OR if there is on enable register for that
+ * peripheral.
  */
 void power_on(peripheral p_peripheral);
 
 /**
  * @brief Power off peripheral
  *
+ * If the peripheral is already powered off, this does nothing.
  */
 void power_off(peripheral p_peripheral);
 


### PR DESCRIPTION
When power_on is called and the peripheral is already powered on, this is considered a violation of the single use principle per each peripheral, which means it will throw. This will detect more than one driver attempting to control a single peripheral. Driver should power of their peripherals if they are no longer using them in their destructor.

Resolves #103