### PR TITLE
Revert ":sparkles: `stm32f1::power_on()` now throws"

### DIFF
--- a/include/libhal-arm-mcu/stm32f1/constants.hpp
+++ b/include/libhal-arm-mcu/stm32f1/constants.hpp
@@ -89,7 +89,6 @@ enum class peripheral : std::uint8_t
   system_timer = beyond_bus + 1,
   i2s = beyond_bus + 2,
 
-  max,
 };
 
 /// List of interrupt request numbers for this platform

--- a/src/stm32f1/power.hpp
+++ b/src/stm32f1/power.hpp
@@ -22,24 +22,12 @@ namespace hal::stm32f1 {
 /**
  * @brief Power on the peripheral
  *
- * This API also acts as a resource overlap detector. If this API is called
- * twice on the same peripheral, it will throw an exception. Only drivers with
- * control over the entire peripheral should call this API for their respective
- * peripheral. This allows this API to detect when two driver attempt to utilize
- * the same resource.
- *
- * @throws hal::device_or_resource_busy - if the peripheral is already powered
- * on, constituting a violation of the 1 peripheral manager per peripheral rule.
- * @throws hal::argument_out_of_domain - if the peripheral's value is outside of
- * the bounds of the enum class OR if there is on enable register for that
- * peripheral.
  */
 void power_on(peripheral p_peripheral);
 
 /**
  * @brief Power off peripheral
  *
- * If the peripheral is already powered off, this does nothing.
  */
 void power_off(peripheral p_peripheral);
 


### PR DESCRIPTION
Reverts libhal/libhal-arm-mcu#104