### PR TITLE
:technologist: Add `BuiltinHeaders: QueryDriver` to `.clangd`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,21 @@
+Checks: "-header-filter=.*,readability-identifier-naming,modernize-*,performance-*,bugprone-*,-modernize-use-trailing-return-type,-checks=-*"
+WarningsAsErrors: "*"
+UseColor: true
+CheckOptions:
+  - { key: readability-identifier-naming.NamespaceCase, value: lower_case }
+  - { key: readability-identifier-naming.ClassCase, value: lower_case }
+  - { key: readability-identifier-naming.VariableCase, value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberCase, value: lower_case }
+  - { key: readability-identifier-naming.PrivateMemberPrefix, value: m_ }
+  - { key: readability-identifier-naming.StructCase, value: lower_case }
+  - { key: readability-identifier-naming.ParameterCasePrefix, value: p_ }
+  - { key: readability-identifier-naming.ParameterCase, value: lower_case }
+  - { key: readability-identifier-naming.FunctionCase, value: lower_case }
+  - { key: readability-identifier-naming.MacroDefinition, value: UPPER_CASE }
+  - { key: readability-identifier-naming.EnumConstantCase, value: lower_case }
+  - { key: readability-identifier-naming.ConstantMemberCase, value: lower_case }
+  - { key: readability-identifier-naming.ClassConstantCase, value: lower_case }
+  - { key: readability-identifier-naming.GlobalConstantCase, value: lower_case }
+  - { key: readability-identifier-naming.LocalConstantCase, value: lower_case }
+  - { key: readability-identifier-naming.StaticConstantCase, value: lower_case }
+  - { key: readability-identifier-naming.ConstantCase, value: lower_case }

--- a/.clangd
+++ b/.clangd
@@ -1,2 +1,3 @@
 CompileFlags:
   CompilationDatabase: .
+  BuiltinHeaders: QueryDriver


### PR DESCRIPTION
This will ensure that the compiler used by `clangd` uses the system headers for that compiler and not the host. Using the host system headers can result false positives in clangd errors due to how those host headers work. On Mac, you get a "No Thead API" error because `stddef.h` requires some macros to be defined in order to provide the correct information. Without this, the macro if/else chain will generate an `#error` saying "No Thead API". Using this `CompilerFlag` eliminates this issue by using the compiler's system include.

Add `.clang-tidy` to enable clang tidy checks in `clangd`.