### PR TITLE
:sparkles: STM32F1 Timer Demo

### DIFF
--- a/demos/CMakeLists.txt
+++ b/demos/CMakeLists.txt
@@ -31,6 +31,7 @@ libhal_build_demos(
   spi
   blank
   # stream_dac
+  timer
 
   PACKAGES
   minimp3

--- a/demos/applications/pwm.cpp
+++ b/demos/applications/pwm.cpp
@@ -24,22 +24,35 @@ void application(resource_list& p_map)
 
   auto& pwm = *p_map.pwm.value();
   auto& clock = *p_map.clock.value();
+  auto& console = *p_map.console.value();
 
   while (true) {
+    pwm.duty_cycle(0.0f);
     pwm.frequency(1.0_kHz);
-
-    for (unsigned iteration = 0; iteration <= 100; iteration += 1) {
-      auto duty_cycle = static_cast<float>(iteration) / 100.0f;
+    hal::print(console, "Sweeping duty cycle from 0 to 1 \n");
+    hal::delay(clock, 1s);
+    float constexpr duty_cycle_step_count = 20;
+    float const duty_cycle_step = 1 / duty_cycle_step_count;
+    for (float duty_cycle = 0; duty_cycle < 1; duty_cycle += duty_cycle_step) {
+      hal::print<64>(console, ">> Duty: %.2f \n", duty_cycle);
       pwm.duty_cycle(duty_cycle);
       hal::delay(clock, 100ms);
     }
 
-    pwm.duty_cycle(0.5f);
+    pwm.duty_cycle(0.0f);
 
-    for (unsigned iteration = 1; iteration < 20; iteration++) {
-      auto const frequency = static_cast<hal::hertz>(100_Hz * iteration);
+    hal::print(console, "Sweeping frequency from 1kHz to 20kHz\n");
+    hal::print(console, ">> pwm Duty Cycle = 50%\n");
+    hal::delay(clock, 1s);
+    pwm.duty_cycle(1.0f / 2);  // 50% duty cycle
+
+    for (float multiplier = 1; multiplier < 20; multiplier++) {
+      float frequency = 1000 /* Hz */ * multiplier;
       pwm.frequency(frequency);
+      hal::print<64>(console, ">> Freq: %f Hz\n", frequency);
       hal::delay(clock, 100ms);
     }
+
+    hal::print(console, "\n");
   }
 }

--- a/demos/applications/pwm16.cpp
+++ b/demos/applications/pwm16.cpp
@@ -24,18 +24,18 @@ void application(resource_list& p_map)
   using namespace std::chrono_literals;
   using namespace hal::literals;
 
-  auto& pwm = *p_map.pwm_channel.value();
+  auto& pwm_channel = *p_map.pwm_channel.value();
   auto& pwm_frequency = *p_map.pwm_frequency.value();
   auto& console = *p_map.console.value();
   auto& clock = *p_map.clock.value();
 
   while (true) {
-    pwm.duty_cycle(0);
+    pwm_channel.duty_cycle(0);
     pwm_frequency.frequency(1.0_kHz);
     hal::print(console,
                "Sweeping duty cycle from 0% (0x0000) to 100% (0xFFFF)\n");
     hal::print<32>(
-      console, ">> PWM Frequency = %" PRIu32 "Hz\n", pwm.frequency());
+      console, ">> pwm Frequency = %" PRIu32 "Hz\n", pwm_channel.frequency());
     hal::delay(clock, 1s);
     auto constexpr duty_cycle_step_count = 20;
     hal::u16 const duty_cycle_step = 0xFFFF / duty_cycle_step_count;
@@ -43,21 +43,22 @@ void application(resource_list& p_map)
          duty_cycle += duty_cycle_step) {
       hal::print<64>(
         console, ">> Duty: 0x%04" PRIX32 " / 0xFFFF \n", duty_cycle);
-      pwm.duty_cycle(duty_cycle);
+      pwm_channel.duty_cycle(duty_cycle);
       hal::delay(clock, 100ms);
     }
 
-    pwm.duty_cycle(0);
+    pwm_channel.duty_cycle(0);
 
     hal::print(console, "Sweeping frequency from 1kHz to 20kHz\n");
-    hal::print(console, ">> PWM Duty Cycle = 50%\n");
+    hal::print(console, ">> pwm Duty Cycle = 50%\n");
     hal::delay(clock, 1s);
-    pwm.duty_cycle(0xFFFF / 2);  // 50% duty cycle
+    pwm_channel.duty_cycle(0xFFFF / 2);  // 50% duty cycle
 
     for (hal::u32 multiplier = 1; multiplier < 20; multiplier++) {
       auto frequency = 1000 /* Hz */ * multiplier;
       pwm_frequency.frequency(frequency);
-      hal::print<64>(console, ">> Freq: %" PRIu32 "Hz\n", pwm.frequency());
+      hal::print<64>(
+        console, ">> Freq: %" PRIu32 "Hz\n", pwm_channel.frequency());
       hal::delay(clock, 100ms);
     }
 

--- a/demos/applications/timer.cpp
+++ b/demos/applications/timer.cpp
@@ -1,0 +1,107 @@
+// Copyright 2024 - 2025 Khalil Estell and the libhal contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cinttypes>
+
+#include <libhal-util/serial.hpp>
+#include <libhal-util/steady_clock.hpp>
+
+#include <resource_list.hpp>
+
+void application(resource_list& p_map)
+{
+  using namespace std::chrono_literals;
+
+  auto& clock = *p_map.clock.value();
+  auto& console = *p_map.console.value();
+  auto& callback_timer = *p_map.callback_timer.value();
+
+  hal::print(console, "Callback timer demo starting...\n\n");
+
+  hal::u64 start_timer = 0;
+  hal::u64 stop_timer = 0;
+  bool volatile interrupt_toggled = false;
+  auto cpu_frequency = static_cast<hal::u32>(clock.frequency());
+
+  struct interrupt_capture_variables
+  {
+    hal::steady_clock& clock;
+    hal::serial& console;
+    hal::u64& stop_timer;
+    bool volatile& interrupt_toggled;
+  };
+  interrupt_capture_variables capture_vars{
+    clock, console, stop_timer, interrupt_toggled
+  };
+
+  auto func_to_call = [&capture_vars]() {
+    capture_vars.stop_timer = capture_vars.clock.uptime();
+    hal::print<128>(capture_vars.console, "\nCallback function executed!\n");
+    capture_vars.interrupt_toggled = true;
+  };
+
+  hal::u64 accumulator = 0;
+  for (int i = 0; i < 10; i++) {
+    start_timer = clock.uptime();
+    callback_timer.schedule(func_to_call, hal::time_duration(10s));
+    stop_timer = clock.uptime();
+    callback_timer.cancel();
+    accumulator += (stop_timer - start_timer);
+  }
+  accumulator /= 10;
+  hal::print<128>(console,
+                  "Average amount of CC to schedule a callback is:%" PRIu64
+                  "\n\n",
+                  accumulator);
+
+  hal::print(console, "Scheduling callback function to occur in 250ms...\n");
+  start_timer = clock.uptime();
+  callback_timer.schedule(func_to_call, 250ms);
+  while (interrupt_toggled == false) {
+    hal::print(console, "Waiting...\n");
+    hal::delay(clock, 50ms);
+  }
+  hal::u64 scale_factor = 1'000'000;
+  auto time_elapsed = (stop_timer - start_timer) * scale_factor / cpu_frequency;
+  hal::print<128>(console, "Time Elapsed:%" PRIu64 "us\n", time_elapsed);
+
+  hal::delay(clock, 1s);
+  hal::print(console, "\nTesting is_scheduled() and cancel() function...\n");
+  callback_timer.schedule(func_to_call, hal::time_duration(10s));
+  hal::delay(clock, 500ms);
+  auto is_scheduled = callback_timer.is_running();
+  auto is_scheduled_string = (is_scheduled) ? "True" : "False";
+  hal::print<128>(
+    console, "Callback scheduled? (Expected True): %s\n", is_scheduled_string);
+  callback_timer.cancel();
+  is_scheduled = callback_timer.is_running();
+  is_scheduled_string = (is_scheduled) ? "True" : "False";
+  hal::print<128>(
+    console, "Callback scheduled? (Expected False): %s\n", is_scheduled_string);
+
+  hal::delay(clock, 1000ms);
+  hal::print(
+    console,
+    "\nTesting overwriting callback functionality (Should take 500ms)...\n");
+  interrupt_toggled = false;
+  callback_timer.schedule(func_to_call, hal::time_duration(10s));
+  start_timer = clock.uptime();
+  callback_timer.schedule(func_to_call, hal::time_duration(500ms));
+  while (interrupt_toggled == false) {
+    hal::print(console, "Waiting...\n");
+    hal::delay(clock, 50ms);
+  }
+  time_elapsed = (stop_timer - start_timer) * scale_factor / cpu_frequency;
+  hal::print<128>(console, "Time Elapsed:%" PRIu64 "us\n", time_elapsed);
+}

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -23,5 +23,5 @@ class demos(ConanFile):
 
     def requirements(self):
         self.requires("libhal-util/[^5.4.0]")
-        self.requires("libhal-arm-mcu/[1.10.0 || latest]")
+        self.requires("libhal-arm-mcu/[1.11.0 || latest]")
         self.requires("minimp3/cci.20211201")

--- a/demos/resource_list.hpp
+++ b/demos/resource_list.hpp
@@ -29,6 +29,7 @@
 #include <libhal/spi.hpp>
 #include <libhal/steady_clock.hpp>
 #include <libhal/stream_dac.hpp>
+#include <libhal/timer.hpp>
 #include <libhal/zero_copy_serial.hpp>
 
 struct resource_list
@@ -52,6 +53,7 @@ struct resource_list
   std::optional<hal::i2c*> i2c;
   std::optional<hal::interrupt_pin*> interrupt_pin;
   std::optional<hal::pwm*> pwm;
+  std::optional<hal::timer*> callback_timer;
   std::optional<hal::pwm16_channel*> pwm_channel;
   std::optional<hal::pwm_group_manager*> pwm_frequency;
   std::optional<hal::spi*> spi;


### PR DESCRIPTION
- Added demo for callback timer.
- Updated old PWM demo to match pwm16's style.
- Updated stm32f1's platform file to add logic for use_libhal_4_pwm.