### PR TITLE
:package: Set python_requires mode to major_mode

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -112,6 +112,7 @@ class libhal_arm_mcu_conan(ConanFile):
                 self.append_linker_using_platform(platform)
 
     def package_id(self):
+        self.info.python_requires.major_mode()
         del self.info.options.use_picolibc
         del self.info.options.use_libhal_exceptions
         del self.info.options.platform


### PR DESCRIPTION
By setting the mode for `python_requires` to `major_mode` only the major_mode

will represent a breaking change between new versions of `libhal-bootstrap`.