### PR TITLE
:bug: (patch) stm32f1: Fix JTAG pin release logic and pin reset detection

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -16,7 +16,7 @@
 
 from conan import ConanFile
 from pathlib import Path
-import os
+from conan.tools.cmake import cmake_layout
 
 
 required_conan_version = ">=2.0.14"
@@ -62,6 +62,14 @@ class libhal_arm_mcu_conan(ConanFile):
         "replace_std_terminate": "Replace the default std::terminate handler to reduce binary size by avoiding verbose text rendering",
         "use_semihosting": "Enables semihosting support, allowing the MCU to perform host based I/O like writing to stdout or reading from files via the debug port. With LLVM from arm-toolchain, semihosting is enabled via the compiler and must be disabled via a build profile option and not this option.",
     }
+
+    def layout(self):
+        build_path = Path("build") / (
+            str(self.options.platform) + "-" +
+            str(self.settings.compiler) + "-" +
+            str(self.settings.compiler.version)
+        )
+        cmake_layout(self, build_folder=str(build_path))
 
     def set_version(self):
         # Use latest if not specified via command line

--- a/demos/conanfile.py
+++ b/demos/conanfile.py
@@ -15,11 +15,21 @@
 # limitations under the License.
 
 from conan import ConanFile
+from pathlib import Path
+from conan.tools.cmake import cmake_layout
 
 
 class demos(ConanFile):
     python_requires = "libhal-bootstrap/[>=4.3.0 <5]"
     python_requires_extend = "libhal-bootstrap.demo"
+
+    def layout(self):
+        build_path = Path("build") / (
+            str(self.options.platform) + "-" +
+            str(self.settings.compiler) + "-" +
+            str(self.settings.compiler.version)
+        )
+        cmake_layout(self, build_folder=str(build_path))
 
     def requirements(self):
         self.requires("libhal-arm-mcu/latest")

--- a/demos/platforms/stm32f103c8.cpp
+++ b/demos/platforms/stm32f103c8.cpp
@@ -470,6 +470,7 @@ void initialize_platform()
       },
     },
   });
+
   hal::stm32f1::activate_mco_pa8(
     hal::stm32f1::mco_source::pll_clock_divided_by_2);
 

--- a/src/stm32f1/pin.cpp
+++ b/src/stm32f1/pin.cpp
@@ -33,6 +33,15 @@ bit_mask config_mask(u8 p_pin)
     .width = 4,
   };
 }
+
+bit_mask config_mode_mask(u8 p_pin)
+{
+  return {
+    .position = static_cast<uint32_t>((p_pin * 4) % 32),
+    .width = 2,
+  };
+}
+
 /// Returns a bit mask indicating where the odr bit is in the output data
 /// register.
 bit_mask odr_mask(u8 p_pin)
@@ -99,7 +108,7 @@ void safely_power_on(pin_select const& p_pin_select)
 
 std::array<gpio_t*, 8> gpio_reg_map{
   reinterpret_cast<gpio_t*>(0x4001'0800),  // 'A'
-  reinterpret_cast<gpio_t*>(0x4001'0c00),  // 'B'
+  reinterpret_cast<gpio_t*>(0x4001'0C00),  // 'B'
   reinterpret_cast<gpio_t*>(0x4001'1000),  // 'C'
   reinterpret_cast<gpio_t*>(0x4001'1400),  // 'D'
   reinterpret_cast<gpio_t*>(0x4001'1800),  // 'E'
@@ -110,10 +119,18 @@ std::array<gpio_t*, 8> gpio_reg_map{
 bool is_pin_reset(pin_select p_pin_select)
 {
   auto& config_reg = config_register(p_pin_select);
+  // NOTE: To check if a pin is in "reset" mode, we simply check to see if the
+  // pin is in the input MODE (MODE=0b00). We ignore the pull up/down resistor
+  // states since these can be different for the JTAG pins (see RM0008 pg. 161)
+  //
+  //    PA15: JTDI in PU
+  //    PA14: JTCK in PD
+  //    PA13: JTMS in PU
+  //    PB4: NJTRST in PU
   auto const current_configuration =
-    bit_extract(config_mask(p_pin_select.pin), config_reg);
+    bit_extract(config_mode_mask(p_pin_select.pin), config_reg);
 
-  return reset_pin_config == current_configuration;
+  return reset_pin_mode == current_configuration;
 }
 }  // namespace
 
@@ -139,6 +156,7 @@ void configure_pin(pin_select p_pin_select, pin_config_t p_config)
       (p_pin_select.port == 'A' && p_pin_select.pin == 15)) {
     release_jtag_pins();
   }
+
   auto& config_reg = config_register(p_pin_select);
   auto& odr_reg = odr_register(p_pin_select);
   safely_power_on(p_pin_select);

--- a/src/stm32f1/pin.hpp
+++ b/src/stm32f1/pin.hpp
@@ -136,6 +136,12 @@ static constexpr auto reset_pin_config = bit_value<u32>(0)
                                            .insert<cnf0>(input_float.CNF0)
                                            .insert<mode>(input_float.MODE)
                                            .get();
+/**
+ * @brief The state of the MODE of a pin in RESET
+ *
+ */
+static constexpr auto reset_pin_mode =
+  bit_value<u32>(0).insert<mode>(input_float.MODE).get();
 
 /**
  * @brief Construct pin manipulation object


### PR DESCRIPTION
- Move JTAG pin release back into configure_pin() to centralize pin configuration logic
- Fix is_pin_reset() to only check MODE field (bits 1-0) instead of all CNF bits, as JTAG pins have different default pull-up/down states per RM0008
- Add config_mode_mask() helper to extract just the MODE bits
- Fix hex casing in GPIO register address (0c00 → 0C00)
- Add conanfile.py layout() method for organized build directory structure
- Minor formatting improvements